### PR TITLE
Change screenshot source in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ Select "JavaScript Template" if it's not automatically working.
 
 ## Screenshot
 
-![screenshot](screenshot.png)
+![screenshot](https://github.com/darron/language-ejs/raw/master/screenshot.png)


### PR DESCRIPTION
So I will be correctly displayed at [atom.io](https://atom.io/packages/language-ejs) and in the Atom editor.